### PR TITLE
Landpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ mechanisms allows configuration.
 * `/bin/caddy` # Server executable
 * `/etc/passwd` # UID to run server
 * `/var/www/html/` # Server working directory and root of HTTP name space
+* `/var/www/html/index.html` # Default landing page
 
 ## Adding Content
 

--- a/root/var/www/html/index.html
+++ b/root/var/www/html/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en-US">
+<head>
+	<meta charset="UTF-8" />
+	<title>Caddy Default Page</title>
+</head>
+<body>
+<h1>Caddy web server Docker container</h1>
+<p>This is the default landing page for the
+<a href="https://registry.hub.docker.com/u/joshix/caddy/"><tt>joshix/caddy</tt></a>
+Docker image.</p>
+</body>
+</html>


### PR DESCRIPTION
Merge the little branch that adds a default `index.html` under `root/var/www/html/`.

This makes the image easier to deploy in a HOWTO-like scenario. `docker run` this image and caddy will be serving a default landing page on port 2015.
