### PR TITLE
port80 branch - run caddy euid 0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,5 @@ FROM scratch
 MAINTAINER Josh Wood <j@joshix.com>
 COPY root /
 EXPOSE 2015
-USER caddy
 WORKDIR /var/www/html
 CMD ["/bin/caddy"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ mechanisms allows configuration.
 
 ## Container file system:
 * `/bin/caddy` # Server executable
-* `/etc/passwd` # UID to run server
 * `/var/www/html/` # Server working directory and root of HTTP name space
 * `/var/www/html/index.html` # Default landing page
 

--- a/root/etc/passwd
+++ b/root/etc/passwd
@@ -1,1 +1,0 @@
-caddy:x:22015:22015:caddy:/nonexistent:/usr/sbin/nologin


### PR DESCRIPTION
Caddy binds port 2015 by default. This requires no user privilege. Since it is convenient to masquerade ports with docker, I liked this default and rigged the image's Dockerfile with `USER` to run the executable as `caddy`, uid 22015.

However, it is not so convenient to map ports in all deployment environments, so you may want to configure your instance to listen on port 80. But when trying to grab a low port as user `caddy`, the _docker run …_ fails when denied permission to bind port 80.

One may mark a Linux executable with a capability to listen on privileged ports regardless of EUID privileges, with something like
    `setcap cap_net_bind_service=+ep ./caddy`

However, the docker build command executing _tar_ can’t transmit this marking into the image, so again we fail to bind port 80 at container run time.

It seems simpler to go back to running as root inside the container, and allows us to remove a file from the image and a line from the Dockerfile and the README.
