### PR TITLE
Specify UID as number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM scratch
 MAINTAINER Josh Wood <j@joshix.com>
 COPY rootfs /
 EXPOSE 2015
-USER caddy
+USER  22015
 WORKDIR /var/www/html
 CMD ["/bin/caddy"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ mechanisms allows configuration.
 
 ## Container file system:
 * `/bin/caddy` - Server executable
-* `/etc/passwd` - User name `caddy` ID `22015`
 * `/etc/ssl/certs/ca-certificates.crt` - Root certificates
 * `/var/www/html/` - Server working directory and root of HTTP name space
 * `/var/www/html/index.html` - Default landing page

--- a/rootfs/etc/passwd
+++ b/rootfs/etc/passwd
@@ -1,1 +1,0 @@
-caddy:x:22015:22015:caddy:/nonexistent:/usr/sbin/nologin


### PR DESCRIPTION
This PR replaces the `Dockerfile`'s `USER caddy` with a raw number UID (`22015`).

The `/etc/passwd` file mapping the user name _caddy_ to a UID integer is thus obsolete and removed.

This makes the image easier to run with `rkt(8)` which currently doesn't support a string user name in a docker image. (viz. https://github.com/coreos/rkt/blob/master/stage1/init/pod.go#L183-L194)
