### PR TITLE
Caddy v8.0

### DIFF
--- a/rootfs/var/www/html/index.html
+++ b/rootfs/var/www/html/index.html
@@ -7,7 +7,7 @@
 <body>
 <h1>Caddy web server Docker container</h1>
 <p>This is the default landing page for the
-<a href="https://registry.hub.docker.com/u/joshix/caddy/"><code>joshix/caddy</code></a>
+<a href="https://hub.docker.com/r/joshix/caddy/"><code>joshix/caddy</code></a>
 Docker image.</p>
 </body>
 </html>


### PR DESCRIPTION
TODO: Update README &c. for the letsencrypt support.
It would be neat to have https by default but we may not always have the hostname in  container.
