### PR TITLE
caddy-rkt.service: Add example systemd unit

### DIFF
--- a/caddy-rkt.service
+++ b/caddy-rkt.service
@@ -1,0 +1,34 @@
+[Unit]
+# Metadata
+Description=Run caddybox Docker container under rkt
+Documentation=https://jxnu.joshix.com/2016/01/23/migration-brief/
+# Wait for networking
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Slice=machine.slice
+# Resource limits
+Delegate=true
+#CPUShares=512
+#MemoryLimit=512M
+# Env vars
+#Environment=HTTP_PROXY=192.0.2.3:5000
+#Environment=STORAGE_PATH=/opt/myapp
+#Environment=TMPDIR=/var/tmp
+# Fetch the image. Superfluous - rkt run will fetch images that don't exist.
+ExecStartPre=/usr/bin/rkt fetch --insecure-options=image docker://quay.io/josh_wood/caddy:0.8.3
+# Start the app
+ExecStart=/usr/bin/rkt run --insecure-options=image \
+--port 80-tcp:80 --port 443-tcp:443 --port 2015-tcp:2015 \
+--dns=8.8.8.8 --dns=8.8.4.4 \
+--volume html,kind=host,source=/home/core/web/public,readOnly=true \
+--mount volume=html,target=/var/www/html \
+--volume dotcaddy,kind=host,source=/home/core/dotcaddy,readOnly=false \
+--mount volume=dotcaddy,target=/root/.caddy \
+docker://quay.io/josh_wood/caddy:0.8.3
+KillMode=mixed
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
`caddy-rkt.service` is a systemd unit for running caddybox with
rkt by pulling the docker container from a registry through
docker2aci.
