### PR TITLE
Dockerfile: Replace CMD with ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ MAINTAINER Josh Wood <j@joshix.com>
 COPY rootfs /
 EXPOSE 80 443 2015
 WORKDIR /var/www/html
-CMD ["/bin/caddy"]
+ENTRYPOINT ["/bin/caddy"]

--- a/caddy-rkt.service
+++ b/caddy-rkt.service
@@ -17,7 +17,7 @@ Delegate=true
 #Environment=STORAGE_PATH=/opt/myapp
 #Environment=TMPDIR=/var/tmp
 # Fetch the image. Superfluous - rkt run will fetch images that don't exist.
-ExecStartPre=/usr/bin/rkt fetch --insecure-options=image docker://quay.io/josh_wood/caddy:v0.10.7
+ExecStartPre=/usr/bin/rkt fetch --insecure-options=image docker://quay.io/josh_wood/caddy:v0.10.7-cb.1
 # Start the app
 ExecStart=/usr/bin/rkt run --insecure-options=image \
 --port 80-tcp:80 --port 443-tcp:443 --port 2015-tcp:2015 \
@@ -26,7 +26,7 @@ ExecStart=/usr/bin/rkt run --insecure-options=image \
 --mount volume=html,target=/var/www/html \
 --volume dotcaddy,kind=host,source=/home/core/dotcaddy,readOnly=false \
 --mount volume=dotcaddy,target=/root/.caddy \
-docker://quay.io/josh_wood/caddy:v0.10.7
+docker://quay.io/josh_wood/caddy:v0.10.7-cb.1
 KillMode=mixed
 Restart=always
 

--- a/rkt-run.md
+++ b/rkt-run.md
@@ -26,7 +26,7 @@ rkt run --insecure-options=image \
 --mount volume=html,target=/var/www/html \
 --volume dotcaddy,kind=host,source=/home/core/dotcaddy,readOnly=false \
 --mount volume=dotcaddy,target=/root/.caddy \
-docker://quay.io/josh_wood/caddy:v0.10.7
+docker://quay.io/josh_wood/caddy:v0.10.7-cb.1
 ```
 
 


### PR DESCRIPTION
ENTRYPOINT allows passing options directly into the container
on docker run. Omitting CMD for default options maintains ideal
caddy and current caddybox behavior.

Update version strings for release of v0.10.7-cb.1.

Fixes #41.