### PR TITLE
Add agree switch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ MAINTAINER Josh Wood <j@joshix.com>
 COPY rootfs /
 EXPOSE 80 443 2015
 WORKDIR /var/www/html
-ENTRYPOINT ["/bin/caddy"]
+ENTRYPOINT ["/bin/caddy", "-agree"]


### PR DESCRIPTION
Had an issue on a new box where caddy was prompting for agreement and exiting. Adding the -agree switch to the entrypoint automatically accepts the Subscriber Agreement and a reading of the documentation shows no issue with having it as the default and in fact is the recommended setting for automated environments.
https://caddyserver.com/docs/cli

Container error message:
`Attaching to caddy
caddy    | Activating privacy features... 
caddy    | 
caddy    | Your sites will be served over HTTPS automatically using Let's Encrypt.
caddy    | By continuing, you agree to the Let's Encrypt Subscriber Agreement at:
caddy    |   https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf
caddy    | Do you agree to the terms? (y/n): 2018/05/02 21:30:30 user must agree to CA terms (use -agree flag)
caddy exited with code 1
`

