### PR TITLE
Caddy v2.5.2: Built with go1.18.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM scratch
 LABEL maintainer="Josh Wood <j@joshix.com>"
-LABEL caddy_version="2.5.1"
+LABEL caddy_version="2.5.2"
 COPY rootfs /
 USER 65534:65534
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Create a Caddyfile specifying, at minimum, a domain name resolving to the docker
 
 ```sh
 cd /tmp/caddyboxbuild
-GOOS=linux GOARCH=amd64 xcaddy build v2.5.1
+GOOS=linux GOARCH=amd64 xcaddy build v2.5.2
 file caddy
 cp caddy [...]/caddybox/rootfs/bin/caddy
 ```


### PR DESCRIPTION
Caddy v2.5.2.
Linux x64 binary `rootfs/bin/caddy` built from [upstream source][caddy-release] with go1.18.4 driven by caddy's [`xcaddy` build tool][xcaddy] v0.3.0: `GOOS=linux GOARCH=amd64 xcaddy build v2.5.2`.

https://quay.io/repository/joshix/caddy

[caddy-release]: https://github.com/caddyserver/caddy/releases/tag/v2.5.2
[xcaddy]: https://github.com/caddyserver/xcaddy
