### PR TITLE
Caddy v2.6.3: Multistage build with xcaddy v0.3.2, go v1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.19.5 AS builder
+FROM golang:1.20 AS builder
 RUN mkdir /build
 WORKDIR /build
-RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.3.1
-RUN GOOS=linux GOARCH=amd64 xcaddy build v2.6.2
+RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.3.2
+RUN GOOS=linux GOARCH=amd64 xcaddy build v2.6.3
 
 FROM scratch
 LABEL maintainer="Josh Wood <j@joshix.com>"
-LABEL caddy_version="2.6.2"
+LABEL caddy_version="2.6.3"
 COPY rootfs /
 COPY --from=builder /build/caddy /bin/caddy
 USER 65534:65534

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Preserved for reference. The build is no longer done out-of-band and the caddy b
 
 ```sh
 cd /tmp/caddyboxbuild
-GOOS=linux GOARCH=amd64 xcaddy build v2.6.2
+GOOS=linux GOARCH=amd64 xcaddy build v2.6.3
 file caddy
 cp caddy [...]/caddybox/rootfs/bin/caddy
 ```


### PR DESCRIPTION
Bump versions of go, xcaddy and caddy atop the new multistage build. New caddy uses newer quic lib which builds with go1.20.