### PR TITLE
Caddy v2.7.4. Xcaddy v0.3.5.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.20 AS builder
+FROM golang:1.21.1 AS builder
 RUN mkdir /build
 WORKDIR /build
-RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.3.4
-RUN xcaddy build v2.7.0-beta.2
+RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.3.5
+RUN xcaddy build v2.7.4
 
 FROM scratch
 LABEL maintainer="Josh Wood <j@joshix.com>"
-LABEL caddy-version="2.7.0-beta.2"
+LABEL caddy-version="2.7.4"
 COPY rootfs /
 COPY --from=builder /build/caddy /bin/caddy
 USER 65534:65534

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM golang:1.20 AS builder
 RUN mkdir /build
 WORKDIR /build
 RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.3.4
-RUN xcaddy build v2.7.0-beta.1
+RUN xcaddy build v2.7.0-beta.2
 
 FROM scratch
 LABEL maintainer="Josh Wood <j@joshix.com>"
-LABEL caddy-version="2.7.0-beta.1"
+LABEL caddy-version="2.7.0-beta.2"
 COPY rootfs /
 COPY --from=builder /build/caddy /bin/caddy
 USER 65534:65534

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1 AS builder
+FROM golang:1.20 AS builder
 RUN mkdir /build
 WORKDIR /build
 RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.3.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:1.20 AS builder
 RUN mkdir /build
 WORKDIR /build
-RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.3.2
-RUN GOOS=linux GOARCH=amd64 xcaddy build v2.6.4
+RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.3.4
+RUN xcaddy build v2.7.0-beta.1
 
 FROM scratch
 LABEL maintainer="Josh Wood <j@joshix.com>"
-LABEL caddy-version="2.6.4"
+LABEL caddy-version="2.7.0-beta.1"
 COPY rootfs /
 COPY --from=builder /build/caddy /bin/caddy
 USER 65534:65534

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Preserved for reference. The build is no longer done out-of-band and the caddy b
 
 ```sh
 cd /tmp/caddyboxbuild
-GOOS=linux GOARCH=amd64 xcaddy build v2.6.4
+GOOS=linux GOARCH=amd64 xcaddy build v2.7.4
 file caddy
 cp caddy [...]/caddybox/rootfs/bin/caddy
 ```


### PR DESCRIPTION
Update caddy to latest version 2.7.4 built by latest xcaddy 0.3.5 with latest go 1.21.1.